### PR TITLE
Add link for MemorialGenWeb

### DIFF
--- a/tag2link/resources/tag2link_sources.xml
+++ b/tag2link/resources/tag2link_sources.xml
@@ -107,7 +107,14 @@
             <link name="View %name% sheet of church" href="http://egliseinfo.catholique.fr/#!lieu:%v%" />
         </rule>
     </src>
-
+   
+   <src name="MemorialGenWeb" country-code="FR">
+        <rule>
+            <condition k="ref:(FR:)?MemorialGenWeb" v="[0-9]*" />
+            <link name="View MemorialGenWeb sheet of memorial" href="http://www.memorial-genweb.org/~memorial2/html/fr/resultcommune.php?idsource=%v%" />
+        </rule>
+    </src>
+   
     <src name="MHS" country-code="FR">
         <rule>
             <condition k="ref:(FR:)?mhs" v="\p{Upper}{2}\p{Digit}{8}" />


### PR DESCRIPTION
If the ref:FR:MemorialGenWeb key is present, adds a link to the MemorialGenWeb site